### PR TITLE
fix dropbox 404 page error

### DIFF
--- a/client/scraper/dropbox_metadata.py
+++ b/client/scraper/dropbox_metadata.py
@@ -4,7 +4,10 @@ from urlparse import parse_qs
 from urlparse import urlsplit
 from urlparse import urlunsplit
 
+from bs4 import BeautifulSoup
+
 from client.constants import FieldKeyword
+from client.constants import StatusCode
 from metadata import Metadata
 
 
@@ -23,14 +26,31 @@ class DropboxMetadata(Metadata):
         return urlunsplit((scheme, netloc, path, new_query_string, fragment))
 
     def parse_content(self, response):
-        self.generic_parse_content(response)
+        soup = BeautifulSoup(response.content)
+        title = self.get_title(soup)
 
-        file_list = collections.OrderedDict()
-        file_list[FieldKeyword.COUNT] = 1
-        file_list[FieldKeyword.DATA] = [
-            {
-                FieldKeyword.URL: self.get_download_url(response.request_url),
-                FieldKeyword.TYPE: None
-            }]
+        # TODO: currently unsure of how to tell if you have landed on a page that has 404ed since dropbox always returns 200 status
+        # the below is a hack to get around this problem, will need to clean this up once we've figured out how to resolve this issue
+        if title == 'Dropbox - Error':
+            self.prop_map[FieldKeyword.STATUS] = StatusCode.NOT_FOUND
+            self.prop_map[FieldKeyword.ERROR_MSG] = StatusCode.get_status_message(StatusCode.NOT_FOUND)
 
-        self.prop_map[FieldKeyword.FILES] = file_list
+            favicon_url = self.get_favicon_url(soup)
+            desc = self.get_desc(soup)
+
+            self.prop_map[FieldKeyword.TITLE] = title
+            self.prop_map[FieldKeyword.FAVICON] = favicon_url
+            self.prop_map[FieldKeyword.DESC] = desc
+
+        else:
+            self.generic_parse_content(response)
+
+            file_list = collections.OrderedDict()
+            file_list[FieldKeyword.COUNT] = 1
+            file_list[FieldKeyword.DATA] = [
+                {
+                    FieldKeyword.URL: self.get_download_url(response.sanitized_url),
+                    FieldKeyword.TYPE: None
+                }]
+
+            self.prop_map[FieldKeyword.FILES] = file_list


### PR DESCRIPTION
this is a huge hack, hitting a 404 page on dropbox currently returns 200 so we manually check to see if it's errored by checking the title
#57 