### PR TITLE
119: Fix for missing image url for image hyperlinks

### DIFF
--- a/client/scraper/metadata.py
+++ b/client/scraper/metadata.py
@@ -166,9 +166,9 @@ class Metadata:
 
             self.prop_map[FieldKeyword.DESC] = self.get_desc(response)
 
-            self.prop_map[FieldKeyword.FAVICON] = self.get_favicon_url(response)
-
             self.prop_map[FieldKeyword.IMAGES] = self.get_images_list(response)
+
+            self.prop_map[FieldKeyword.FAVICON] = self.get_favicon_url(response)
 
             self.prop_map[FieldKeyword.MEDIA] = self.get_media_list(response)
 


### PR DESCRIPTION
It's a quick fix, will be automatically resolved once favicon bug is fixed